### PR TITLE
Support and require pytest>=3.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Take a trivial test like:
     def test_simple():
         a = 1
         b = 2
-        assert 1 + 2 == 3
+        assert a + b == 3
 
 View the rewritten AST as Python like this:
 

--- a/pytest_ast_back_to_python.py
+++ b/pytest_ast_back_to_python.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 
 from _pytest.assertion.rewrite import rewrite_asserts
-from _pytest.monkeypatch import monkeypatch
+from _pytest.monkeypatch import MonkeyPatch
 
 import codegen
 
@@ -22,9 +22,9 @@ def pytest_configure(config):
     config.pluginmanager.register(config._ast_as_python)
 
 def make_replacement_rewrite_asserts(store):
-    def replacement_rewrite_asserts(tree):
-        rewrite_asserts(tree)
-        store.append(codegen.to_source(tree))
+    def replacement_rewrite_asserts(mod, module_path=None, config=None):
+        rewrite_asserts(mod, module_path, config)
+        store.append(codegen.to_source(mod))
     return replacement_rewrite_asserts
 
 class AstAsPython(object):
@@ -35,7 +35,7 @@ class AstAsPython(object):
         if not config.getoption('ast_as_python'):
             return
 
-        mp = monkeypatch()
+        mp = MonkeyPatch()
         mp.setattr(
             '_pytest.assertion.rewrite.rewrite_asserts',
             make_replacement_rewrite_asserts(self.store))

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     description='A plugin for pytest devs to view how assertion rewriting recodes the AST',
     long_description=read('README.rst'),
     py_modules=['pytest_ast_back_to_python', 'codegen'],
-    install_requires=['pytest>=2.8.1'],
+    install_requires=['pytest>=3.0.0'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Hi @tomviner!

I used your plugin to investigate pytest-dev/pytest#2131, this PR makes the plugin work with pytest >= 3.0. I didn't try to keep compatibility with earlier versions, but let me know if you prefer that; is not that hard to keep compatibility.

Cheers,
🍻 