### PR TITLE
Fix pytest 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,12 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7-dev"
+  - "3.7"
+  - "3.8-dev"
   - "nightly"
-  - "pypy"
 
 install:
   - pip install tox coveralls pytest-travis-fold

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,8 @@ python:
   - "nightly"
 
 install:
-  - pip install tox coveralls pytest-travis-fold
-  - TOX_ENV=$(python -c "import sys;print('py{}{}'.format(*sys.version_info[:2]))")
-script: tox -e $TOX_ENV
+  - pip install tox-travis coveralls pytest-travis-fold
+script: tox
 
 before_cache:
   - rm -rf $HOME/.cache/pip/log

--- a/README.rst
+++ b/README.rst
@@ -63,16 +63,18 @@ View the rewritten AST as Python like this:
     def test_simple():
         a = 1
         b = 2
-        @py_assert0 = 1
-        @py_assert2 = 2
-        @py_assert4 = @py_assert0 + @py_assert2
-        @py_assert6 = 3
-        @py_assert5 = @py_assert4 == @py_assert6
-        if not @py_assert5:
-            @py_format8 = @pytest_ar._call_reprcompare(('==',), (@py_assert5,), ('(%(py1)s + %(py3)s) == %(py7)s',), (@py_assert4, @py_assert6)) % {'py3': @pytest_ar._saferepr(@py_assert2), 'py1': @pytest_ar._saferepr(@py_assert0), 'py7': @pytest_ar._saferepr(@py_assert6)}
-            @py_format10 = ('' + 'assert %(py9)s') % {'py9': @py_format8}
-            raise AssertionError(@pytest_ar._format_explanation(@py_format10))
-        @py_assert0 = @py_assert2 = @py_assert4 = @py_assert5 = @py_assert6 = None
+        @py_assert2 = a + b
+        @py_assert4 = 3
+        @py_assert3 = @py_assert2 == @py_assert4
+        if @py_assert3 is None:
+            from _pytest.warning_types import PytestAssertRewriteWarning
+            from warnings import warn_explicit
+            warn_explicit(PytestAssertRewriteWarning('asserting the value None, please use "assert is None"'), category=None, filename='/home/tom/.virtualenvs/tmp-483cf04ecc31dda8/test_thing.py', lineno=4)
+        if not @py_assert3:
+            @py_format6 = @pytest_ar._call_reprcompare(('==',), (@py_assert3,), ('(%(py0)s + %(py1)s) == %(py5)s',), (@py_assert2, @py_assert4)) % {'py0': @pytest_ar._saferepr(a) if 'a' in @py_builtins.locals() or @pytest_ar._should_repr_global_name(a) else 'a', 'py1': @pytest_ar._saferepr(b) if 'b' in @py_builtins.locals() or @pytest_ar._should_repr_global_name(b) else 'b', 'py5': @pytest_ar._saferepr(@py_assert4)}
+            @py_format8 = ('' + 'assert %(py7)s') % {'py7': @py_format6}
+            raise AssertionError(@pytest_ar._format_explanation(@py_format8))
+        @py_assert2 = @py_assert3 = @py_assert4 = None
 
 
 Contributing

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,6 @@ environment:
     - PYTHON: "C:\\Python27"
       TOX_ENV: "py27"
 
-    - PYTHON: "C:\\Python33"
-      TOX_ENV: "py33"
-
     - PYTHON: "C:\\Python34"
       TOX_ENV: "py34"
 

--- a/pytest_ast_back_to_python.py
+++ b/pytest_ast_back_to_python.py
@@ -17,16 +17,20 @@ def pytest_addoption(parser):
         help='Show how assertion rewriting recoded the AST.'
     )
 
+
 def pytest_configure(config):
     config._ast_as_python = AstAsPython()
     config.pluginmanager.register(config._ast_as_python)
 
-def make_replacement_rewrite_asserts(store):
-    def replacement_rewrite_asserts(mod, source, module_path=None, config=None):
-        rewrite_asserts(mod, source, module_path, config)
 
+def make_replacement_rewrite_asserts(store):
+
+    def replacement_rewrite_asserts(mod, *args, **kwargs):
+        rewrite_asserts(mod, *args, **kwargs)
         store.append(codegen.to_source(mod))
+
     return replacement_rewrite_asserts
+
 
 class AstAsPython(object):
     def __init__(self):

--- a/pytest_ast_back_to_python.py
+++ b/pytest_ast_back_to_python.py
@@ -22,8 +22,9 @@ def pytest_configure(config):
     config.pluginmanager.register(config._ast_as_python)
 
 def make_replacement_rewrite_asserts(store):
-    def replacement_rewrite_asserts(mod, module_path=None, config=None):
-        rewrite_asserts(mod, module_path, config)
+    def replacement_rewrite_asserts(mod, source, module_path=None, config=None):
+        rewrite_asserts(mod, source, module_path, config)
+
         store.append(codegen.to_source(mod))
     return replacement_rewrite_asserts
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     description='A plugin for pytest devs to view how assertion rewriting recodes the AST',
     long_description=read('README.rst'),
     py_modules=['pytest_ast_back_to_python', 'codegen'],
-    install_requires=['pytest>=3.0.0'],
+    install_requires=['pytest'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(fname):
 
 setup(
     name='pytest-ast-back-to-python',
-    version='1.0.1',
+    version='1.1.0',
     author='Tom Viner',
     author_email='code@viner.tv',
     maintainer='Tom Viner',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(fname):
 
 setup(
     name='pytest-ast-back-to-python',
-    version='1.1.0',
+    version='1.2.0',
     author='Tom Viner',
     author_email='code@viner.tv',
     maintainer='Tom Viner',

--- a/tests/test_ast_back_to_python.py
+++ b/tests/test_ast_back_to_python.py
@@ -18,7 +18,7 @@ def test_ast_as_python_on(testdir):
 
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines([
-        '*::test_ast_as_python_on PASSED',
+        '*::test_ast_as_python_on PASSED*',
     ])
     # The expression within the assert statement should be broken down to
     # constituent parts like this:
@@ -48,7 +48,7 @@ def test_ast_as_python_off(testdir):
 
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines([
-        '*::test_ast_as_python_off PASSED',
+        '*::test_ast_as_python_off PASSED*',
     ])
     assert '@py_assert' not in result.stdout.str()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,9 @@
 # For more information about tox, see https://tox.readthedocs.org/en/latest/
 [tox]
-envlist = py27,py33,py34,py35,py36,py37,pypy
+envlist =
+    py{27,34,35,36,37,38,39}-pytest{30,31,32,33,34,35,36,37,38,39,310,40,41,42,43,44,45,46}
+    py{35,36,37,38,39}-pytest{50,51}
+
 
 [testenv]
 usedevelop = true
@@ -8,4 +11,24 @@ passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps =
     pytest
     pytest-cov
+    pytest30: pytest==3.0.*
+    pytest31: pytest==3.1.*
+    pytest32: pytest==3.2.*
+    pytest33: pytest==3.3.*
+    pytest34: pytest==3.4.*
+    pytest35: pytest==3.5.*
+    pytest36: pytest==3.6.*
+    pytest37: pytest==3.7.*
+    pytest38: pytest==3.8.*
+    pytest39: pytest==3.9.*
+    pytest310: pytest==3.10.*
+    pytest40: pytest==4.0.*
+    pytest41: pytest==4.1.*
+    pytest42: pytest==4.2.*
+    pytest43: pytest==4.3.*
+    pytest44: pytest==4.4.*
+    pytest45: pytest==4.5.*
+    pytest46: pytest==4.6.*
+    pytest50: pytest==5.0.*
+    pytest51: pytest==5.1.*
 commands = pytest --cov pytest_ast_back_to_python --cov-report term-missing {posargs:tests}

--- a/tox.ini
+++ b/tox.ini
@@ -9,26 +9,25 @@ envlist =
 usedevelop = true
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps =
-    pytest
     pytest-cov
-    pytest30: pytest==3.0.*
-    pytest31: pytest==3.1.*
-    pytest32: pytest==3.2.*
-    pytest33: pytest==3.3.*
-    pytest34: pytest==3.4.*
-    pytest35: pytest==3.5.*
-    pytest36: pytest==3.6.*
-    pytest37: pytest==3.7.*
-    pytest38: pytest==3.8.*
-    pytest39: pytest==3.9.*
-    pytest310: pytest==3.10.*
-    pytest40: pytest==4.0.*
-    pytest41: pytest==4.1.*
-    pytest42: pytest==4.2.*
-    pytest43: pytest==4.3.*
-    pytest44: pytest==4.4.*
-    pytest45: pytest==4.5.*
-    pytest46: pytest==4.6.*
-    pytest50: pytest==5.0.*
-    pytest51: pytest==5.1.*
+    pytest30: pytest~=3.0.0
+    pytest31: pytest~=3.1.0
+    pytest32: pytest~=3.2.0
+    pytest33: pytest~=3.3.0
+    pytest34: pytest~=3.4.0
+    pytest35: pytest~=3.5.0
+    pytest36: pytest~=3.6.0
+    pytest37: pytest~=3.7.0
+    pytest38: pytest~=3.8.0
+    pytest39: pytest~=3.9.0
+    pytest310: pytest~=3.10.0
+    pytest40: pytest~=4.0.0
+    pytest41: pytest~=4.1.0
+    pytest42: pytest~=4.2.0
+    pytest43: pytest~=4.3.0
+    pytest44: pytest~=4.4.0
+    pytest45: pytest~=4.5.0
+    pytest46: pytest~=4.6.0
+    pytest50: pytest~=5.0.0
+    pytest51: pytest~=5.1.0
 commands = pytest --cov pytest_ast_back_to_python --cov-report term-missing {posargs:tests}

--- a/tox.ini
+++ b/tox.ini
@@ -9,13 +9,14 @@ envlist =
 usedevelop = true
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps =
-    pytest-cov
     pytest30: pytest~=3.0.0
     pytest31: pytest~=3.1.0
     pytest32: pytest~=3.2.0
     pytest33: pytest~=3.3.0
     pytest34: pytest~=3.4.0
     pytest35: pytest~=3.5.0
+    pytest{30,31,32,33,34,35}: pytest-cov<2.6.0
+    pytest{36,37,38,39,310,40,41,42,43,44,45,46,50,51}: pytest-cov
     pytest36: pytest~=3.6.0
     pytest37: pytest~=3.7.0
     pytest38: pytest~=3.8.0


### PR DESCRIPTION
Simplify how args are passed though the replacement rewrite function. This is enable compatibility with a wide selection of Pytest versions, where different numbers of args have been passed/are expected. Luckily the arg we want is always in the first position.

Also, upgrade the CI config and test against a wide selection of Pytest versions.